### PR TITLE
Write method to get_bit to avoid complicated gating algorithm

### DIFF
--- a/lab2/lab2_src.c
+++ b/lab2/lab2_src.c
@@ -6,7 +6,10 @@
 
 
 #include <stdio.h>
-#include <math.h>
+#include <stdbool.h>
+
+// Function Prototype
+bool get_bit(int number, int index);
 
 int main(int argc, char * argv[])
 {
@@ -18,29 +21,24 @@ int main(int argc, char * argv[])
 	{
 		
 		for (int i = 7; i >= 0; i--)
-		{
-			gate = 0;
-			if (i < 7)
-			{
-				for (int x = i + 2; x > i + 1; x--)
-					gate += (pow(2, x-1) -1);
-			}
-			else
-				gate = 255;
-			
+		{	
 
-			if ((number & gate) >> i)
-			{
+			if (get_bit(number, i))
 				printf("Turn on LED: %d\n", i+1);
-			}
 			else
 				printf("Turn off LED: %d\n", i + 1);
 			
 		}
-
 	}
 
 	return 0;
 }
 
+bool get_bit(int number, int index)
+{
+	unsigned flag = 1;
+	
+	flag = flag << index;
 
+	return number & flag;
+}


### PR DESCRIPTION
I replaced the complicated gating logic with a get_bit function

This function uses the left bit shift operator << on the number 1 to move the 1 over 'n' number of bits

(ex. 1 << 2 = 100)

The logic I used before technically worked, but this also works and is WAY simpler to understand and probably faster as well

(Also avoids bringing in math.h library)